### PR TITLE
Tempest/add ai coding tools techstack

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ yarn-error.log*
 /test-results/
 /playwright-report/
 /playwright/.cache/
+.playwright-mcp/

--- a/src/__tests__/config-structure.test.js
+++ b/src/__tests__/config-structure.test.js
@@ -47,12 +47,9 @@ describe('Config Structure Validation', () => {
     expect(projectsHeader.customUrl).toBe('Projects/Project');
   });
 
-  it('should have Resume as link type with customUrl', () => {
+  it('should not have Resume in the menu headers', () => {
     const resumeHeader = config.headers.find(h => h.title === 'Resume');
-    expect(resumeHeader).toBeDefined();
-    expect(resumeHeader.type).toBe('link');
-    expect(resumeHeader.customUrl).toBeDefined();
-    expect(resumeHeader.customUrl).toMatch(/^https?:\/\//);
+    expect(resumeHeader).toBeUndefined();
   });
 
   it('should have Links header', () => {
@@ -65,6 +62,7 @@ describe('Config Structure Validation', () => {
     const markdownHeader = config.headers.find(h => h.title === 'MarkDown');
     expect(markdownHeader).toBeDefined();
     expect(markdownHeader.type).toBe('article');
+    expect(markdownHeader.icon).toBe('bi-markdown');
   });
 
   it('should have Blog header', () => {

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -10,8 +10,8 @@ import config from '../config';
 import styles from '../styles/header.module.css';
 import PropTypes from 'prop-types';
 import { useDispatch, useSelector } from 'react-redux';
-import { handleUrl } from '../util/url';
-import { navigate, goBack, selectPage } from '../util/store'
+import { externalValidator, formatLink, handleUrl } from '../util/url';
+import { navigate, selectPage } from '../util/store'
 import { compareLowerCase } from '../util/str';
 import { useTheme } from './ThemeProvider';
 
@@ -21,24 +21,45 @@ const Header = () => {
   const dispatch = useDispatch();
   const { isDark, toggleTheme, themeEnabled } = useTheme();
 
+  const getHeaderLabel = (item) => item.ariaLabel || item.title;
+
   const setPage = (page) => {
     dispatch(navigate(page));
   }
   const pageUpdate = (item) => {
     handleUrl(item.customUrl || item.title, setPage)
   }
+  const getHeaderUrl = (item) => {
+    const destination = item.customUrl || item.title;
+    return externalValidator(destination) ? destination : formatLink(destination);
+  }
   // render header links with the active page
   const getHeaders = () => {
     const headerLinks = [];
     config.headers.forEach(item => {
+      const destination = item.customUrl || item.title;
+      const external = externalValidator(destination);
+
       headerLinks.push(
         <li className={styles['header-link-wrapper']} key={`navbar-link-${item.title}`}>
           <a
-            className="nav-link"
+            className={`nav-link ${styles['header-link-anchor']} ${item.icon ? styles['header-link-icon-only'] : ''}`}
             data-active={compareLowerCase(item.title, page) || compareLowerCase(item.customUrl, page) ? 'active' : ''}
-            onClick={() => pageUpdate(item)}
+            aria-label={getHeaderLabel(item)}
+            title={getHeaderLabel(item)}
+            href={getHeaderUrl(item)}
+            target={external ? '_blank' : undefined}
+            rel={external ? 'noreferrer noopener' : undefined}
+            onClick={(e) => {
+              e.preventDefault();
+              pageUpdate(item);
+            }}
           >
-            {item.title}
+            {
+              item.icon
+                ? <i className={`bi ${item.icon} ${styles['header-link-icon']}`} aria-hidden="true"></i>
+                : item.title
+            }
           </a>
         </li>
       );

--- a/src/config.js
+++ b/src/config.js
@@ -43,17 +43,21 @@ const config = {
       customUrl: 'Projects/Project'
     },
     {
-      title: 'MarkDown',
-      type: 'article'
-    },
-    {
-      title: 'Resume',
-      type: 'link',
-      customUrl: 'https://drive.google.com/file/d/1aNJ-NPuk71x4xQgRo5Es2WPyNZA8kbCb/view?usp=sharing'
-    },
-    {
       title: 'Links',
       type: 'article'
+    },
+    {
+      title: 'MarkDown',
+      type: 'article',
+      icon: 'bi-markdown',
+      ariaLabel: 'Markdown Editor'
+    },
+    {
+      title: '3D Portfolio',
+      type: 'link',
+      customUrl: 'https://3d.tempest.fun/',
+      icon: 'bi-badge-3d',
+      ariaLabel: '3D Portfolio'
     }
   ],
   // markdown settings

--- a/src/styles/header.module.css
+++ b/src/styles/header.module.css
@@ -27,6 +27,24 @@
     color: #feb272!important;
 }
 
+.header-link-anchor {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.35rem;
+}
+
+.header-link-icon-only {
+    min-width: 2rem;
+    font-size: 1.15rem;
+    line-height: 1;
+}
+
+.header-link-icon {
+    display: block;
+    line-height: 1;
+}
+
 .header-controller {
     display: flex;
     flex-direction: row;

--- a/tests/menu-navigation.spec.js
+++ b/tests/menu-navigation.spec.js
@@ -5,6 +5,8 @@
 import { test, expect } from '@playwright/test';
 
 test.describe('Menu Navigation', () => {
+  const menuItem = (page, label) => page.locator(`nav a[aria-label="${label}"]`);
+
   test.beforeEach(async ({ page }) => {
     // Navigate to home page before each test
     await page.goto('/');
@@ -25,18 +27,17 @@ test.describe('Menu Navigation', () => {
     await expect(navLinks).toBeVisible();
 
     // Verify specific menu items from config are present
-    const expectedMenuItems = ['About', 'Tech Stack', 'Blog', 'Projects', 'MarkDown', 'Resume', 'Links'];
+    const expectedMenuItems = ['About', 'Tech Stack', 'Blog', 'Projects', 'Markdown Editor', '3D Portfolio', 'Links'];
 
     for (const menuItem of expectedMenuItems) {
-      // Menu items are rendered as links within the navbar
-      const menuLink = page.locator('nav').getByText(menuItem, { exact: true });
+      const menuLink = page.locator(`nav a[aria-label="${menuItem}"]`);
       await expect(menuLink, `Menu item "${menuItem}" should be visible`).toBeVisible();
     }
   });
 
   test('clicking About menu item should display About content', async ({ page }) => {
     // Click on About menu item
-    const aboutLink = page.locator('nav').getByText('About', { exact: true });
+    const aboutLink = menuItem(page, 'About');
     await aboutLink.click();
 
     // Wait for content to load
@@ -58,7 +59,7 @@ test.describe('Menu Navigation', () => {
   });
 
   test('clicking Tech Stack menu item should display Tech Stack content', async ({ page }) => {
-    const techStackLink = page.locator('nav').getByText('Tech Stack', { exact: true });
+    const techStackLink = menuItem(page, 'Tech Stack');
     await techStackLink.click();
 
     await page.waitForLoadState('networkidle');
@@ -70,11 +71,11 @@ test.describe('Menu Navigation', () => {
 
     // Verify the active state is applied
     const activeLink = page.locator('a[data-active="active"]');
-    await expect(activeLink).toContainText('Tech');
+    await expect(activeLink).toHaveAttribute('aria-label', 'Tech Stack');
   });
 
   test('clicking Blog menu item should display Blog content', async ({ page }) => {
-    const blogLink = page.locator('nav').getByText('Blog', { exact: true });
+    const blogLink = menuItem(page, 'Blog');
     await blogLink.click();
 
     await page.waitForLoadState('networkidle');
@@ -86,11 +87,11 @@ test.describe('Menu Navigation', () => {
 
     // Verify the active state is applied
     const activeLink = page.locator('a[data-active="active"]');
-    await expect(activeLink).toContainText('Blog');
+    await expect(activeLink).toHaveAttribute('aria-label', 'Blog');
   });
 
   test('clicking MarkDown menu item should show the markdown editor', async ({ page }) => {
-    const markdownLink = page.locator('nav').getByText('MarkDown', { exact: true });
+    const markdownLink = menuItem(page, 'Markdown Editor');
     await markdownLink.click();
 
     await page.waitForLoadState('networkidle');
@@ -106,11 +107,11 @@ test.describe('Menu Navigation', () => {
 
     // Verify the active state is applied
     const activeLink = page.locator('a[data-active="active"]');
-    await expect(activeLink).toContainText('MarkDown');
+    await expect(activeLink).toHaveAttribute('aria-label', 'Markdown Editor');
   });
 
   test('clicking Projects menu item should display Projects content', async ({ page }) => {
-    const projectsLink = page.locator('nav').getByText('Projects', { exact: true });
+    const projectsLink = menuItem(page, 'Projects');
     await projectsLink.click();
 
     await page.waitForLoadState('networkidle');
@@ -122,11 +123,11 @@ test.describe('Menu Navigation', () => {
 
     // Verify the active state is applied
     const activeLink = page.locator('a[data-active="active"]');
-    await expect(activeLink).toContainText('Projects');
+    await expect(activeLink).toHaveAttribute('aria-label', 'Projects');
   });
 
   test('clicking Links menu item should display Links content', async ({ page }) => {
-    const linksLink = page.locator('nav').getByText('Links', { exact: true });
+    const linksLink = menuItem(page, 'Links');
     await linksLink.click();
 
     await page.waitForLoadState('networkidle');
@@ -138,20 +139,20 @@ test.describe('Menu Navigation', () => {
 
     // Verify the active state is applied
     const activeLink = page.locator('a[data-active="active"]');
-    await expect(activeLink).toContainText('Links');
+    await expect(activeLink).toHaveAttribute('aria-label', 'Links');
   });
 
-  test('clicking Resume menu item should open external link in new tab', async ({ page, context }) => {
+  test('clicking 3D Portfolio menu item should open external link in new tab', async ({ page, context }) => {
     // Wait for any potential popup
     const [newPage] = await Promise.all([
       context.waitForEvent('page', { timeout: 5000 }).catch(() => null),
-      page.locator('nav').getByText('Resume', { exact: true }).click()
+      menuItem(page, '3D Portfolio').click()
     ]);
 
     if (newPage) {
-      // If a new page was opened, verify it's the resume link
+      // If a new page was opened, verify it's the portfolio link
       await newPage.waitForLoadState('networkidle');
-      await expect(newPage).toHaveURL(/drive.google.com/);
+      await expect(newPage).toHaveURL(/3d\.tempest\.fun/);
       await newPage.close();
     } else {
       // For external links that might not open in new tab in test environment,
@@ -162,22 +163,22 @@ test.describe('Menu Navigation', () => {
 
   test('menu item should show active state for current page', async ({ page }) => {
     // Click on Blog
-    await page.locator('nav').getByText('Blog', { exact: true }).click();
+    await menuItem(page, 'Blog').click();
     await page.waitForLoadState('networkidle');
     await page.waitForTimeout(300);
 
     // Verify the active state is applied to Blog link
     const activeLink = page.locator('a[data-active="active"]');
-    await expect(activeLink).toContainText('Blog');
+    await expect(activeLink).toHaveAttribute('aria-label', 'Blog');
 
     // Navigate to another page
-    await page.locator('nav').getByText('About', { exact: true }).click();
+    await menuItem(page, 'About').click();
     await page.waitForLoadState('networkidle');
     await page.waitForTimeout(300);
 
     // Verify active state is now on About
     const newActiveLink = page.locator('a[data-active="active"]');
-    await expect(newActiveLink).toContainText('About');
+    await expect(newActiveLink).toHaveAttribute('aria-label', 'About');
   });
 
   test('navigation should work correctly on mobile viewport', async ({ page }) => {
@@ -195,7 +196,7 @@ test.describe('Menu Navigation', () => {
     await page.waitForTimeout(300);
 
     // Menu items should be visible in the collapsed menu
-    const aboutLink = page.locator('nav').getByText('About', { exact: true });
+    const aboutLink = menuItem(page, 'About');
     await expect(aboutLink).toBeVisible();
 
     // Navigate via mobile menu


### PR DESCRIPTION
  Summary

  - Update header navigation to support icon-only menu items with proper accessibility attributes (aria-label, title, href)
  - Remove Resume link and add 3D Portfolio external link and Markdown Editor with icon-only display
  - Add Codex and Claude Code badges to Tech Stack article
  - Refactor tests to use aria-label selectors for more robust menu item targeting

  Changes

  Config (src/config.js)
  - Removed Resume external link
  - Added 3D Portfolio link (https://3d.tempest.fun/) with bi-badge-3d icon
  - Added icon and ariaLabel fields to MarkDown entry
  - Reordered menu items (Links moved before MarkDown)

  Header Component (src/components/Header.jsx)
  - Added support for icon-only menu items via item.icon field
  - Links now render with proper href, target="_blank", and rel attributes for external URLs
  - Added aria-label and title attributes for accessibility
  - Added helper functions getHeaderLabel() and getHeaderUrl()

  Styles (src/styles/header.module.css)
  - Added .header-link-anchor, .header-link-icon-only, .header-link-icon classes for icon-only link styling

  Tech Stack (src/articles/TechStack.md)
  - Added Codex SVG badge and Claude Code shield badge
  
  Tests
  - Updated unit test to expect Resume to be absent from config
  - Updated E2E tests to use aria-label selectors instead of text matching
  - Updated expected menu items and external link URL assertions

  Test plan

  - Verify header displays icon-only items (MarkDown, 3D Portfolio) correctly
  - Verify 3D Portfolio link opens in new tab
  - Verify Resume link is no longer present
  - Run npm run build for compilation check
  - Run npm test for unit tests
  - Run npm run test:e2e for Playwright tests